### PR TITLE
Update bootstrap to always get gitignore and README

### DIFF
--- a/bin/cwtest-bootstrap.sh
+++ b/bin/cwtest-bootstrap.sh
@@ -12,5 +12,5 @@ wget http://selenium-release.storage.googleapis.com/2.49/selenium-server-standal
 # Copy over the sample files directory.
 BIN_DIR="$(dirname $(readlink $BASH_SOURCE))"
 cp -nR ${BIN_DIR}/../Sample_Files/* ./../
-cp -nR ${BIN_DIR}/../README.md ./../
-cp -nR ${BIN_DIR}/../.gitignore ./../
+cp -R ${BIN_DIR}/../README.md ./../
+cp -R ${BIN_DIR}/../.gitignore ./../


### PR DESCRIPTION
Update bootstrap to always copy across the gitignore and README.
