### PR TITLE
Remove behat from composer file so that we use the default that comes…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     }
   ],
   "require": {
-    "behat/behat": "3.0.6",
     "drupal/drupal-extension": "~3.0",
     "emuse/behat-html-formatter": "0.1.0",
     "phpunit/phpunit": "*"


### PR DESCRIPTION
Remove behat from composer file so that we use the default that come with drupal-extension.
