### PR TITLE
Bootstrap issues on Mac OSX due to wget

### DIFF
--- a/bin/cwtest-bootstrap.sh
+++ b/bin/cwtest-bootstrap.sh
@@ -7,7 +7,15 @@ mkdir ./../Results/Behat
 mkdir ./../Results/Behat/screenshots
 
 # Download selenium
-wget https://selenium-release.storage.googleapis.com/2.52/selenium-server-standalone-2.52.0.jar -O ./../Servers/selenium.jar
+SELENIUM_URL="https://selenium-release.storage.googleapis.com/2.52/selenium-server-standalone-2.52.0.jar"
+SELENIUM_DESTINATION="./../Servers/selenium.jar"
+if type wget -v >/dev/null 2>&1; then
+  wget ${SELENIUM_URL} -O ${SELENIUM_DESTINATION}
+elif type curl -V >/dev/null 2>&1; then
+  curl ${SELENIUM_URL} -O ${SELENIUM_DESTINATION}
+else
+  echo "Unable to download Selenium. Please download it from ${SELENIUM_URL} and place it in ${SELENIUM_DESTINATION}"
+fi
 
 # Copy over the sample files directory.
 BIN_DIR="$(dirname $(readlink $BASH_SOURCE))"


### PR DESCRIPTION
Thanks for the great talk at DrupalCamp London!

Just tried this out, but the /bin/cwtest-bootstrap.sh script fails due to using wget to download selenium, as wget isn't available on OSX (by default - it is available via homebrew).

Based on http://stackoverflow.com/a/7522866, I've adjusted it to:
- Check if wget exists, and use that if so
- If not, check if curl exists & use that if so
- Otherwise, provide instructions on downloading manually

Not sure if master is the right branch to merge this to, but it seems you've been using this rather than develop.

Cheers :)
