### PR TITLE
Remove new version of behat

### DIFF
--- a/Sample_Files/Behat/behat.yml
+++ b/Sample_Files/Behat/behat.yml
@@ -54,8 +54,6 @@ default:
     pretty: true
     html:
       output_path: %paths.base%/../Results/Behat
-    junit:
-      output_path: %paths.base%/../Results/Behat/junit
 
 imports:
   - behat.local.yml

--- a/bin/cwtest-bootstrap.sh
+++ b/bin/cwtest-bootstrap.sh
@@ -5,7 +5,6 @@ mkdir ./../Servers
 mkdir ./../Results
 mkdir ./../Results/Behat
 mkdir ./../Results/Behat/screenshots
-mkdir ./../Results/Behat/junit
 
 # Download selenium
 SELENIUM_URL="https://selenium-release.storage.googleapis.com/2.52/selenium-server-standalone-2.52.0.jar"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     }
   ],
   "require": {
-    "behat/behat": "3.1.0",
+    "behat/behat": "3.0.6",
     "drupal/drupal-extension": "3.1.5",
     "emuse/behat-html-formatter": "0.1.0",
     "phpunit/phpunit": "*"


### PR DESCRIPTION
New version not working well with the drupal extension - so reverting back to previous behat version of 3.0.6.
