### PR TITLE
Improves startup Selenium shell scripts

### DIFF
--- a/Sample_Files/Behat/run-behat.sh
+++ b/Sample_Files/Behat/run-behat.sh
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/bin/bash -e
 
 ##############################################################################
 ###    BACKUP PREVIOUS RESULT FILES
 ##############################################################################
 mkdir -p ../Results/History
-mv ../Results/*.html ../Results/History
+ls ../Results/*.html && mv ../Results/*.html ../Results/History
 
 
 ##############################################################################
@@ -38,7 +38,7 @@ fi
 if [ -z $PROFILE ] || [ -z $TAG ]
 then
    printf 'ERROR: Expected Tag followed by Profile.\nE.g. ./run-behat.sh [tag] [profile]\n'
-   exit 0
+   exit 1
 fi
 
 
@@ -47,7 +47,10 @@ fi
 ##############################################################################
 if [ $PROFILE = "firefox" ] || [ $PROFILE = "chrome"  ]
 then
-   sh $COMPOSER_BIN/start_selenium_server.sh;
+   if ! . "$COMPOSER_BIN/start_selenium_server.sh"; then
+     printf 'ERROR: Failed to run Selenium server!\n'
+     exit 1
+   fi
    if [ ! -z "$SCENARIO_NAME" ]
    then
       $COMPOSER_BIN/behat -c behat.yml --tags=@$TAG -p $PROFILE --name="$SCENARIO_NAME"
@@ -75,5 +78,5 @@ fi
 #  Stop Selenium server.
 if [ $PROFILE = "firefox" ] || [ $PROFILE = "chrome"  ]
 then
-   sh $COMPOSER_BIN/stop_selenium_server.sh
+   . $COMPOSER_BIN/stop_selenium_server.sh
 fi

--- a/bin/start_phantomjs_webdriver.sh
+++ b/bin/start_phantomjs_webdriver.sh
@@ -1,21 +1,24 @@
-#!/bin/bash
+#!/bin/bash -e
 
 function checkAndStartPhantomJS {
-  if ! lsof -i:4445
+  if ! </dev/tcp/localhost/4445
   then
     echo Port 4445 is free
     printf "\nStarting phantomjs...\n"
     runPhantomJS
-    sleep 4;
+    return $?
   else
     echo Port 4445 is in use
     printf "\nPhantomjs already running.\n"
+    return 0
   fi
 }
 
 function runPhantomJS {
   phantomjs --webdriver=4445 &
+  local err_code=$?
+  sleep 4
+  return $err_code
 }
 
 checkAndStartPhantomJS
-

--- a/bin/start_selenium_server.sh
+++ b/bin/start_selenium_server.sh
@@ -3,7 +3,8 @@ CWD="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 SELENIUM_PATH="${SELENIUM_PATH:-$(find "$CWD/.." -name selenium.jar -print -quit)}"
 
 function checkAndStartSeleniumServer {
-  if ! </dev/tcp/localhost/4444; then
+  if ! </dev/tcp/localhost/4444
+  then
     printf "Port 4444 is free - starting Selenium server...\n"
     runSeleniumServer
     return $?
@@ -16,9 +17,11 @@ function checkAndStartSeleniumServer {
 function runSeleniumServer {
   if [ "$SELENIUM_PATH" ] && [ -f "$SELENIUM_PATH" ]; then
     java -jar "$SELENIUM_PATH" -port 4444 -trustAllSSLCertificates &
-    return $?
+    local err_code=$?
+    sleep 4
+    return $err_code
   else
-    printf "Selenium JAR not found, please run manually or specify path by SELENIUM_PATH!\n"
+    printf "Selenium JAR not found, please run manually or specify its path by SELENIUM_PATH!\n"
   fi
   return 1
 }

--- a/bin/start_selenium_server.sh
+++ b/bin/start_selenium_server.sh
@@ -1,18 +1,26 @@
-#!/bin/bash
+#!/bin/bash -e
+CWD="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
+SELENIUM_PATH="${SELENIUM_PATH:-$(find "$CWD/.." -name selenium.jar -print -quit)}"
 
 function checkAndStartSeleniumServer {
-  if ! lsof -i:4444
-  then
-    printf "Port 4444 is free - starting selenium server...\n"
+  if ! </dev/tcp/localhost/4444; then
+    printf "Port 4444 is free - starting Selenium server...\n"
     runSeleniumServer
-    sleep 4;
+    return $?
   else
-    printf "Port 4444 is in use - selenium server already running.\n"
+    printf "Port 4444 is in use - Selenium server is already running.\n"
+    return 0
   fi
 }
 
 function runSeleniumServer {
-  java -jar ../Servers/selenium.jar -port 4444 -trustAllSSLCertificates &
+  if [ "$SELENIUM_PATH" ] && [ -f "$SELENIUM_PATH" ]; then
+    java -jar "$SELENIUM_PATH" -port 4444 -trustAllSSLCertificates &
+    return $?
+  else
+    printf "Selenium JAR not found, please run manually or specify path by SELENIUM_PATH!\n"
+  fi
+  return 1
 }
 
 checkAndStartSeleniumServer

--- a/bin/start_selenium_server.sh
+++ b/bin/start_selenium_server.sh
@@ -15,15 +15,16 @@ function checkAndStartSeleniumServer {
 }
 
 function runSeleniumServer {
-  if [ "$SELENIUM_PATH" ] && [ -f "$SELENIUM_PATH" ]; then
+  if type selenium-server; then
+    selenium-server &
+  elif [ "$SELENIUM_PATH" ] && [ -f "$SELENIUM_PATH" ]; then
     java -jar "$SELENIUM_PATH" -port 4444 -trustAllSSLCertificates &
-    local err_code=$?
-    sleep 4
-    return $err_code
   else
     printf "Selenium JAR not found, please run manually or specify its path by SELENIUM_PATH!\n"
   fi
-  return 1
+  local err_code=$?
+  sleep 4
+  return $err_code
 }
 
 checkAndStartSeleniumServer

--- a/bin/stop_phantomjs_webdriver.sh
+++ b/bin/stop_phantomjs_webdriver.sh
@@ -1,8 +1,5 @@
-#!/bin/bash
+#!/bin/bash -e
 
-#  Stop Phantom JS
+# Stop PhantomJS.
 printf "\nStopping phantom webdriver...\n"
-pgrep phantomjs | xargs kill
-
-
-
+pkill phantomjs

--- a/bin/stop_selenium_server.sh
+++ b/bin/stop_selenium_server.sh
@@ -1,8 +1,5 @@
-#!/bin/bash
+#!/bin/bash -e
 
-#  Stop Selenium Server
+# Stop Selenium Server.
 printf "\nStopping selenium server...\n"
 cURL http://localhost:4444/selenium-server/driver/?cmd=shutDownSeleniumServer
-
-
-


### PR DESCRIPTION
This PR fixes inconsistencies and improves the syntax by:
- returning the right exit code for scripts,
- run Bash scripts by bash, not sh,
- don't run behat tests if start selenium script fails,
- now `selenium.jar` is looked in parent folder, not just in `../Servers` which doesn't exist by default,
- selenium JAR path can be overridden by `SELENIUM_PATH`,
- drops dependency for `lsof` (it's not always installed), instead use builtin Bash syntax,
- use simpler syntax, such as `pkill` instead of combination of `pgrep` and `xargs`