### PR TITLE
Use pkill instead of curl request to shutdown Selenium server

### DIFF
--- a/bin/stop_selenium_server.sh
+++ b/bin/stop_selenium_server.sh
@@ -2,7 +2,7 @@
 
 #  Stop Selenium Server
 printf "\nStopping selenium server...\n"
-cURL http://localhost:4444/selenium-server/driver/?cmd=shutDownSeleniumServer
+pkill -f selenium
 
 
 


### PR DESCRIPTION
Fixes: #71

Use `pkill` instead of `curl` to shutdown Selenium server since URL request does not work in Selenium 3 anymore.

> `-f` - The pattern is normally only matched against the process name. When -f is set, the full command line is used.