### PR TITLE
Fixes syntax of including PHPUnit 6.x class

### DIFF
--- a/Sample_Files/src/Context/PageContext.php
+++ b/Sample_Files/src/Context/PageContext.php
@@ -9,7 +9,7 @@ namespace CWTest\Context;
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use PHPUnit_Framework_Assert as Assertions;
+use PHPUnit\Framework\Assert as Assertions;
 
 /**
  * Class PageContext


### PR DESCRIPTION
Since [`composer.json`](https://github.com/cameronandwilding/CWTest_Behat) file defines the latest `phpunit` package by:

    "phpunit/phpunit": "*"

the `PageContext.php` file should be updated to work in PHPUnit 6.x.

Basically `PHPUnit_Framework_Assert` class has been removed and namespace syntax should be used instead.

Related:

- Behat/Behat/issues/1059
- sebastianbergmann/phpunit/issues/2585