### PR TITLE
Adds support for specifying custom Behat parameters

### DIFF
--- a/Sample_Files/Behat/run-behat.sh
+++ b/Sample_Files/Behat/run-behat.sh
@@ -47,22 +47,26 @@ fi
 ##############################################################################
 if [ $PROFILE = "firefox" ] || [ $PROFILE = "chrome"  ]
 then
-   if ! . "$COMPOSER_BIN/start_selenium_server.sh"; then
+   if ! . "$COMPOSER_BIN"/start_selenium_server.sh
+   then
      printf 'ERROR: Failed to run Selenium server!\n'
      exit 1
    fi
    if [ ! -z "$SCENARIO_NAME" ]
    then
-      $COMPOSER_BIN/behat -c behat.yml --tags=@$TAG -p $PROFILE --name="$SCENARIO_NAME"
+      $COMPOSER_BIN/behat -c behat.yml --tags=@$TAG -p $PROFILE --name="$SCENARIO_NAME" ${@:4}
    else
-      $COMPOSER_BIN/behat -c behat.yml --tags=@$TAG -p $PROFILE
+      $COMPOSER_BIN/behat -c behat.yml --tags=@$TAG -p $PROFILE ${@:4}
    fi
 fi
 
 if [ $PROFILE = "phantomjs" ]
 then
-   sh $COMPOSER_BIN/start_phantomjs_webdriver.sh;
-   $COMPOSER_BIN/behat --tags=@$TAG -p $PROFILE
+   if ! . "$COMPOSER_BIN"/start_phantomjs_webdriver.sh; then
+     printf 'ERROR: Failed to run PhantomJS web driver!\n'
+     exit 1
+   fi
+   $COMPOSER_BIN/behat --tags=@$TAG -p $PROFILE ${@:4}
 fi
 
 

--- a/bin/start_selenium_server.sh
+++ b/bin/start_selenium_server.sh
@@ -21,6 +21,7 @@ function runSeleniumServer {
     java -jar "$SELENIUM_PATH" -port 4444 -trustAllSSLCertificates &
   else
     printf "Selenium JAR not found, please run manually or specify its path by SELENIUM_PATH!\n"
+    false
   fi
   local err_code=$?
   sleep 4


### PR DESCRIPTION
This PR aims to add the support for custom `behat` options, for example:

    ./run-behat.sh sometag chrome "" --stop-on-failure

so `--stop-on-failure` is passed to `behat` command it-self.

Other changes includes syntax improvements (for consistency), handling the error when PhantomJS web driver failed to run, and gives false exit code when Selenium was not run successfully.