### PR TITLE
Corrects path to files_path in behat.yml

### DIFF
--- a/Sample_Files/Behat/behat.yml
+++ b/Sample_Files/Behat/behat.yml
@@ -14,7 +14,7 @@ default:
         - Drupal\DrupalExtension\Context\DrupalContext
   extensions:
     Behat\MinkExtension:
-      files_path: %paths.base%/images
+      files_path: %paths.base%/../vendor/cw/behat_test/Sample_Files/Behat/images
       goutte: ~
     Drupal\DrupalExtension:
       blackbox: ~


### PR DESCRIPTION
I believe the `files_path` for `MinkExtension` in sample `behat.yml` file should be corrected to avoid confusion.

By default the sample `.jpg` and `.zip` files exists in [`Sample_Files/Behat/images/`](https://github.com/cameronandwilding/CWTest_Behat/tree/master/Sample_Files/Behat/images) under Composer `vendor/` folder (as per `composer.json`), so I think it should point by default to the existing files, it can always change to other folder later on.

Otherwise the tests fails with the following error:

> And I attach the zipfile "150x350.zip" to the Zip field 
> unknown error: path is not absolute: 150x350.zip