### PR TITLE
Corrects shell scripts to run context independent (GH-46)

### DIFF
--- a/Sample_Files/Behat/behat.yml
+++ b/Sample_Files/Behat/behat.yml
@@ -14,7 +14,7 @@ default:
         - Drupal\DrupalExtension\Context\DrupalContext
   extensions:
     Behat\MinkExtension:
-      files_path: %paths.base%/../vendor/cw/behat_test/Sample_Files/Behat/images
+      files_path: %paths.base%/images
       goutte: ~
     Drupal\DrupalExtension:
       blackbox: ~

--- a/Sample_Files/Behat/run-behat.sh
+++ b/Sample_Files/Behat/run-behat.sh
@@ -1,16 +1,16 @@
 #!/bin/bash -e
 
 ##############################################################################
-###    BACKUP PREVIOUS RESULT FILES
-##############################################################################
-mkdir -p ../Results/History
-ls ../Results/*.html && mv ../Results/*.html ../Results/History
-
-
-##############################################################################
 ###    GLOBAL VARS
 ##############################################################################
-COMPOSER_BIN=../bin
+CWD="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
+COMPOSER_BIN="$CWD"/../bin
+
+##############################################################################
+###    BACKUP PREVIOUS RESULT FILES
+##############################################################################
+mkdir -p "$CWD"/../Results/History
+ls "$CWD"/../Results/*.html && mv "$CWD"/../Results/*.html "$CWD"/../Results/History
 
 ##############################################################################
 ###    ASSIGN SCRIPT VARIABLES
@@ -18,7 +18,6 @@ COMPOSER_BIN=../bin
 TAG=$1
 PROFILE=$2
 SCENARIO_NAME=$3
-
 
 ##############################################################################
 ###    HELP OPTION
@@ -31,7 +30,6 @@ if [ "$1" == "-h" ]; then
   exit 0
 fi
 
-
 ##############################################################################
 ###    SHELL SCRIPT MUST ALWAYS BE PASSED THE TAG AND PROFILE VARIABLES
 ##############################################################################
@@ -40,7 +38,6 @@ then
    printf 'ERROR: Expected Tag followed by Profile.\nE.g. ./run-behat.sh [tag] [profile]\n'
    exit 1
 fi
-
 
 ##############################################################################
 ###    TEST EXECUTION
@@ -54,9 +51,9 @@ then
    fi
    if [ ! -z "$SCENARIO_NAME" ]
    then
-      $COMPOSER_BIN/behat -c behat.yml --tags=@$TAG -p $PROFILE --name="$SCENARIO_NAME" ${@:4}
+      "$COMPOSER_BIN"/behat -c "$CWD"/behat.yml --tags=@$TAG -p $PROFILE --name="$SCENARIO_NAME" ${@:4}
    else
-      $COMPOSER_BIN/behat -c behat.yml --tags=@$TAG -p $PROFILE ${@:4}
+      "$COMPOSER_BIN"/behat -c "$CWD"/behat.yml --tags=@$TAG -p $PROFILE ${@:4}
    fi
 fi
 
@@ -66,9 +63,8 @@ then
      printf 'ERROR: Failed to run PhantomJS web driver!\n'
      exit 1
    fi
-   $COMPOSER_BIN/behat --tags=@$TAG -p $PROFILE ${@:4}
+   "$COMPOSER_BIN"/behat --tags=@$TAG -p $PROFILE ${@:4}
 fi
-
 
 ##############################################################################
 ###    TEARDOWN
@@ -76,11 +72,11 @@ fi
 #  Stop PhantomJS webdriver.
 if [ $PROFILE = "phantomjs" ]
 then
-   sh $COMPOSER_BIN/stop_phantomjs_webdriver.sh
+   . "$COMPOSER_BIN"/stop_phantomjs_webdriver.sh
 fi
 
 #  Stop Selenium server.
 if [ $PROFILE = "firefox" ] || [ $PROFILE = "chrome"  ]
 then
-   . $COMPOSER_BIN/stop_selenium_server.sh
+   . "$COMPOSER_BIN"/stop_selenium_server.sh
 fi

--- a/bin/cwtest-bootstrap.sh
+++ b/bin/cwtest-bootstrap.sh
@@ -1,16 +1,14 @@
-#!/bin/sh
+#!/bin/bash -e
+CWD="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 # Make directories.
-mkdir ./../Servers
-mkdir ./../Results
-mkdir ./../Results
-mkdir ./../Results/screenshots
+mkdir -vp "$CWD"/../Servers "$CWD"/../Results/screenshots
 
 # Download selenium
 SELENIUM_URL="https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.1.jar"
-SELENIUM_DESTINATION="./../Servers/selenium.jar"
+SELENIUM_DESTINATION="${CWD}/../Servers/selenium.jar"
 if type wget -v >/dev/null 2>&1; then
-  wget ${SELENIUM_URL} -O ${SELENIUM_DESTINATION}
+  wget -nc ${SELENIUM_URL} -O ${SELENIUM_DESTINATION}
 elif type curl -V >/dev/null 2>&1; then
   curl ${SELENIUM_URL} -O ${SELENIUM_DESTINATION}
 else
@@ -18,8 +16,9 @@ else
 fi
 
 # Copy over the sample files directory.
-BIN_DIR="$(dirname $(readlink $BASH_SOURCE))"
-cp -nR ${BIN_DIR}/../Sample_Files/* ./../
-cp -R ${BIN_DIR}/../README.md ./../
-cp -R ${BIN_DIR}/../.gitignore ./../
-cp ${BIN_DIR}/../Sample_Files/Behat/run-behat.sh ./../Behat
+SAMPLE_DIR=$(find "${CWD}"/.. -type d -name "Sample_Files" -print -quit)
+if [ -d "$SAMPLE_DIR" ]; then
+  cp -vnR "${SAMPLE_DIR}"/* "${CWD}"/../
+  cp -vn "${SAMPLE_DIR}"/../*.md "${SAMPLE_DIR}"/../.git* "${CWD}"/../
+  cp -vn "${SAMPLE_DIR}"/Behat/*.sh "${CWD}"/../Behat/
+fi


### PR DESCRIPTION
Fixes #46.

So now the scripts can work when run from different folders.

--

Also reverting changes from #76 (`behat.yml`) as my understanding is that `cwtest-bootstrap.sh` supposed to copy those files to the right path after run, so the images path was fine I guess.